### PR TITLE
Simple LSM verse api retriever wrapper

### DIFF
--- a/api/app/models/concerns/lsm_verse_retriever.rb
+++ b/api/app/models/concerns/lsm_verse_retriever.rb
@@ -1,0 +1,45 @@
+require 'net/http'
+require 'uri'
+class LsmVerseRetriever
+
+  ENDPOINT = 'https://api.lsm.org/recver.php'
+
+
+  def retrieve(reference)
+    params = { String: reference, Out: 'json' }
+
+    uri = URI.parse(ENDPOINT)
+    uri.query = URI.encode_www_form(params)
+    @result = Net::HTTP.get(uri)
+  end
+
+  def invalid?
+    first_verse_ref.empty? || (first_verse_text == "No such reference")
+  end
+
+  def valid?
+    !invalid?
+  end
+
+  def text
+    first_verse_text
+  end
+
+  private
+
+  def result_json
+    JSON.parse(@result)
+  end
+
+  def first_verse_ref
+    result_json["verses"].first["ref"]
+  end
+
+  def first_verse_text
+    result_json["verses"].first["text"]
+  end
+
+  def params
+  end
+
+end

--- a/api/spec/models/concerns/lsm_verse_retriever_spec.rb
+++ b/api/spec/models/concerns/lsm_verse_retriever_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe LsmVerseRetriever do
+  # this spec is baaaad because it actually hits the api but whatev
+  describe "#retrieve" do
+    it "populates the result with verse attributes when valid" do
+      retriever = LsmVerseRetriever.new
+      retriever.retrieve("Matthew 1:1")
+      expect(retriever.valid?).to be_truthy
+      expect(retriever.text).to match(/generation/)
+    end
+    it "detects an invalid reference" do
+      retriever = LsmVerseRetriever.new
+
+      retriever.retrieve("Nargh")
+      expect(retriever.valid?).to be_falsey
+    end
+  end
+end
+
+# valid JSON response for one verse:
+#
+# {"inputstring"=>"Matthew 1:1", "detected"=>"Matt. 1:1.", "verses"=>[{"ref"=>"Matt. 1:1", "text"=>"The book of the generation of Jesus Christ, the son of David, the son of Abraham:"}], "message"=>"", "copyright"=>"Verses accessed from the Holy Bible Recovery Version (text-only edition) © 2012 Living Stream Ministry www.lsm.org"}
+#
+#
+# INVALID reference JSON
+#
+#{"inputstring"=>"Nargh", "detected"=>" .", "verses"=>[{"ref"=>" :", "text"=>"No such reference"}], "message"=>"", "copyright"=>"Verses accessed from the Holy Bible Recovery Version (text-only edition) © 2012 Living Stream Ministry www.lsm.org"}


### PR DESCRIPTION
Makes one api call per verse, which is inefficient but I don't
want to have to handle batching right now.

simplicity!