### PR TITLE
GameList also orders by created_at

### DIFF
--- a/src/GamesQuery.js
+++ b/src/GamesQuery.js
@@ -5,7 +5,7 @@ import GamesList from './GamesList';
 
 const GET_GAMES = gql`
   subscription getGames {
-    game_sessions(order_by: {status: asc}, where: {_not: {status: {_eq: "COMPLETED"}}}) {
+    game_sessions(order_by: {status: asc, created_at: desc}, where: {_not: {status: {_eq: "COMPLETED"}}}) {
       id
       status
       uuid


### PR DESCRIPTION
I was thinking it made more sense to sort games by time created (so if you just made a game it wouldn't be at the bottom)... Status is still ordered_by first so it prioritizes it I think... 

IDK what is best so I just pull req'd